### PR TITLE
Pub sub/cancel subscriber with token

### DIFF
--- a/src/heitech.zer0mqXt.core/Main/Socket.cs
+++ b/src/heitech.zer0mqXt.core/Main/Socket.cs
@@ -46,7 +46,7 @@ namespace heitech.zer0mqXt.core.Main
         public void RegisterSubscriber<TMessage>(Action<TMessage> callback, CancellationToken cancellationToken = default)
             where TMessage : class, new()
         {
-            _pubSub.SubscribeHandler(callback, unsubscribeWhen: () => cancellationToken.IsCancellationRequested);
+            _pubSub.SubscribeHandler(callback, unsubscribeWhen: () => !cancellationToken.IsCancellationRequested);
         }
 
         public async Task<TResult> RequestAsync<TRequest, TResult>(TRequest request)

--- a/src/heitech.zer0mqXt.core/Main/Socket.cs
+++ b/src/heitech.zer0mqXt.core/Main/Socket.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using heitech.zer0mqXt.core.infrastructure;
@@ -39,14 +40,15 @@ namespace heitech.zer0mqXt.core.Main
         public void RegisterAsyncSubscriber<TMessage>(Func<TMessage, Task> asyncCallback, CancellationToken cancellationToken = default)
             where TMessage : class, new()
         {
-            // todo should not return a task...also does not use token yet
-            _pubSub.SubscribeAsyncHandler(asyncCallback).Wait();
+            var result = _pubSub.SubscribeHandlerAsync(asyncCallback, cancellationToken);
+            ThrowOnNonSuccess(result);
         }
 
         public void RegisterSubscriber<TMessage>(Action<TMessage> callback, CancellationToken cancellationToken = default)
             where TMessage : class, new()
         {
-            _pubSub.SubscribeHandler(callback, unsubscribeWhen: () => !cancellationToken.IsCancellationRequested);
+            var result = _pubSub.SubscribeHandler(callback, cancellationToken);
+            ThrowOnNonSuccess(result);
         }
 
         public async Task<TResult> RequestAsync<TRequest, TResult>(TRequest request)

--- a/src/heitech.zer0mqXt.core/Patterns/PubSub.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/PubSub.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using heitech.zer0mqXt.core.infrastructure;
@@ -12,98 +13,220 @@ namespace heitech.zer0mqXt.core.patterns
     internal class PubSub : IDisposable
     {
         private readonly SocketConfiguration _configuration;
+        private readonly object _concurrencyToken = new object();
+        private readonly List<IDisposable> _handlers = new List<IDisposable>();
         public PubSub(SocketConfiguration configuration)
         {
             this._configuration = configuration;
         }
 
+        #region Publishing
         public async Task<XtResult<TMessage>> PublishAsync<TMessage>(TMessage message)
             where TMessage : class, new()
         {
-            using var pubSocket = new PublisherSocket();
-            pubSocket.Connect(_configuration.Address());
-
-            return await Task.Run(() => 
+            PublisherSocket publisherSocket = null;
+            try
             {
-                try
+                publisherSocket = new PublisherSocket();
+                publisherSocket.Connect(_configuration.Address());
+                return await Task.Run(() => 
                 {
-                    var msg = new PubSubMessage<TMessage>(_configuration, message);
-                    pubSocket.SendMultipartMessage(msg);
-                }
-                catch (System.Exception ex)
-                {
-                    return XtResult<TMessage>.Failed(ex, "publish");
-                }
+                    try
+                    {
+                        var msg = new PubSubMessage<TMessage>(_configuration, message);
+                        publisherSocket.SendMultipartMessage(msg);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        return XtResult<TMessage>.Failed(ex, "publish");
+                    }
 
-                return XtResult<TMessage>.Success(message, "publish");
-            });
+                    return XtResult<TMessage>.Success(message, "publish");
+                });
+                
+            }
+            catch (System.Exception ex)
+            {
+                return XtResult<TMessage>.Failed(ex, "publish");
+            }
+            finally
+            {
+                publisherSocket?.Dispose();
+            }
         }
+        #endregion
 
-
+        #region Subscribing
         private ManualResetEvent eventHandle;
         ///<summary>
         /// Register a Subscriber for the type TMessage
         /// <para>The unsubscribe callback is used to stop the subscriber</para>
         ///</summary>
-        public void SubscribeHandler<TMessage>(Action<TMessage> callback, Func<bool> unsubscribeWhen = null)
+        public XtResult SubscribeHandler<TMessage>(Action<TMessage> callback, CancellationToken token)
             where TMessage : class, new()
         {
+            return RegisterHandler<TMessage>(syncCallback: callback, token: token);
+        }
+
+        public XtResult SubscribeHandlerAsync<TMessage>(Func<TMessage, Task> asyncCallback, CancellationToken token)
+            where TMessage : class, new()
+        {
+            return RegisterHandler<TMessage>(asyncCallback: asyncCallback, token: token);
+        }
+
+        private XtResult RegisterHandler<TMessage>(Action<TMessage> syncCallback = null, Func<TMessage, Task> asyncCallback = null, CancellationToken token = default)
+            where TMessage : class, new()
+        {
+            Exception exception = null;
             // handle notifies when the server is set up
             eventHandle = new ManualResetEvent(false);
-            Exception exception = null;
 
-            Task.Run(() => 
+            var task = Task.Run(() => 
             {
-                using var subSocket = new SubscriberSocket();
+                var next = new SubscriberHandler<TMessage>
+                (
+                    new SubscriberSocket(), 
+                    _configuration, 
+                    new NetMQ.NetMQPoller(), 
+                    token, 
+                    syncCallback: syncCallback, 
+                    asyncCallback: asyncCallback
+                );
+
+                var (success, exception) = next.Setup();
+                // open resetevent after using setup on the handler and after the poller has started asynchronously
+                // dispose handler when an exception was registered during setup
+                if (exception is not null) 
+                {
+                    next.Dispose(); 
+                    return;
+                }
+
+                // add subscriber to dispsables to get rid of them later
+                lock (_concurrencyToken)
+                {
+                    _handlers.Add(next);
+                }
+                eventHandle.Set();
+            });
+
+            eventHandle.WaitOne();
+            if (exception is not null)
+                return XtResult.Failed(exception, "register-subscriber");
+
+            return XtResult.Success("register-subscriber");
+        }
+
+        private class SubscriberHandler<TMessage> : IDisposable
+             where TMessage : class, new()
+        {
+            private readonly Action<TMessage> _syncCallback;
+            private readonly Func<TMessage, Task> _asyncCallback;
+            private readonly NetMQPoller _poller;
+            private readonly CancellationToken token;
+            private readonly SubscriberSocket _socket;
+            private readonly SocketConfiguration _configuration;
+            private bool _disposedValue;
+            private EventHandler<NetMQSocketEventArgs> _socketDelegate;
+
+            internal SubscriberHandler(SubscriberSocket subscriberSocket,
+                                       SocketConfiguration configuration,
+                                       NetMQPoller poller,
+                                       CancellationToken token,
+                                       Action<TMessage> syncCallback = null,
+                                       Func<TMessage, Task> asyncCallback = null)
+            {
+                this.token = token;
+                this._poller = poller;
+                this._socket = subscriberSocket;
+                this._configuration = configuration;
+                this._syncCallback = syncCallback;
+                this._asyncCallback = asyncCallback;
+            }
+
+            public (bool success, Exception ex) Setup()
+            {
+                Exception exception = null;
                 try
                 {
+                    _socketDelegate = async (s, arg) => await HandleAsync();
+                    _socket.ReceiveReady += _socketDelegate;
+                    
                     string catchAllTopic = "";
-                    subSocket.Bind(_configuration.Address());
-                    subSocket.Subscribe(catchAllTopic);
+                    _socket.Bind(_configuration.Address());
+                    // todo use actual topics instead of catchall
+                    _socket.Subscribe(catchAllTopic);
                     _configuration.Logger.Log(new DebugLogMsg($"subscribed to [{typeof(TMessage)}]"));
+                    _poller.Add(_socket);
+                    _poller.RunAsync();
+
+                    return (true, null);
                 }
                 catch (NetMQ.EndpointNotFoundException ntfnd)
                 {
                     _configuration.Logger.Log(new ErrorLogMsg(ntfnd.Message));
                     exception = ntfnd;
+                    return (false, exception);
                 }
-                // open resetevent after binding to the socket, and block after that
-                eventHandle.Set();
-                if (exception is not null) 
-                    return;
+            }
 
-                bool isRunning = true;
-                while (isRunning)
+            public async Task HandleAsync()
+            {
+                if (this.token.IsCancellationRequested)
                 {
-                    try
-                    {
-                        NetMQMessage received = subSocket.ReceiveMultipartMessage();
-                        var actualMessage = received.ParsePubSubMessage<TMessage>(_configuration);
-                        callback(actualMessage.IsSuccess ? actualMessage.GetResult() : new TMessage());
-                    }
-                    catch (NetMQ.TerminatingException trmnt)
-                    {
-                        isRunning = false;
-                        _configuration.Logger.Log(new ErrorLogMsg($"Subscriber handle for [Message:{typeof(TMessage)}] did fail: " + trmnt.Message));
-                    }
-                    catch (System.Exception ex)
-                    {
-                        _configuration.Logger.Log(new ErrorLogMsg($"Subscriber handle for [Message:{typeof(TMessage)}] did fail: " + ex.Message));
-                    }
-                    isRunning = isRunning && (unsubscribeWhen?.Invoke() ?? true);
+                    Dispose();
+                    _configuration.Logger.Log(new InfoLogMsg("SubscriberHandler was cancelled by cancellationRequest"));
+                    return;
                 }
-            });
 
-            eventHandle.WaitOne();
-            if (exception is not null) 
-                throw exception;
-        }
+                try
+                {
+                    NetMQMessage received = _socket.ReceiveMultipartMessage();
+                    _configuration.Logger.Log(new DebugLogMsg($"handling message for [Subscriber:{typeof(TMessage)}]"));
+                    var actualMessage = received.ParsePubSubMessage<TMessage>(_configuration);
 
-        public async Task SubscribeAsyncHandler<TMessage>(Func<TMessage, Task> asyncCallback)
-            where TMessage : class, new()
-        {
-            await Task.CompletedTask;
+                    var msg = actualMessage.IsSuccess ? actualMessage.GetResult() : new TMessage();
+                    if (this._asyncCallback is null)
+                        _syncCallback(msg);
+                    else
+                        await _asyncCallback(msg);
+                }
+                catch (NetMQ.TerminatingException trmnt)
+                {
+                    _configuration.Logger.Log(new ErrorLogMsg($"Subscriber handle for [Message:{typeof(TMessage)}] did fail: " + trmnt.Message));
+                }
+                catch (System.Exception ex)
+                {
+                    _configuration.Logger.Log(new ErrorLogMsg($"Subscriber handle for [Message:{typeof(TMessage)}] did fail: " + ex.Message));
+                }
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_disposedValue)
+                {
+                    if (disposing)
+                    {
+                        if (_poller != null && _poller.IsRunning)
+                            _poller.Stop();
+                        else 
+                            _socket.Dispose();
+
+                        if (_socket != null && _socketDelegate != null)
+                            _socket.ReceiveReady -= _socketDelegate;
+
+                    }
+                    _disposedValue = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(disposing: true);
+                GC.SuppressFinalize(this);
+            }
         }
+        #endregion
 
         #region Dispose
         private bool disposedValue;
@@ -113,6 +236,7 @@ namespace heitech.zer0mqXt.core.patterns
             if (!disposedValue)
             {
                 disposedValue = true;
+                _handlers.ForEach(x => x.Dispose());
             }
         }
 

--- a/src/heitech.zer0mqXt.core/Patterns/PubSub.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/PubSub.cs
@@ -81,7 +81,7 @@ namespace heitech.zer0mqXt.core.patterns
             // handle notifies when the server is set up
             eventHandle = new ManualResetEvent(false);
 
-            Task.Run(() => 
+            _ = Task.Run(() => 
             {
                 var next = new SubscriberHandler<TMessage>
                 (
@@ -210,7 +210,7 @@ namespace heitech.zer0mqXt.core.patterns
                         if (_poller != null && _poller.IsRunning)
                             _poller.Stop();
                         else 
-                            _socket.Dispose();
+                            _socket?.Dispose();
 
                         if (_socket != null && _socketDelegate != null)
                             _socket.ReceiveReady -= _socketDelegate;

--- a/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
@@ -153,7 +153,6 @@ namespace heitech.zer0mqXt.core.patterns
                     receiveHandler = async (s, e) => await ResponseHandlerCallback(responseSocket, handler, token);
                     responseSocket.ReceiveReady += receiveHandler;
 
-                    // poller blocks, so it has to be started after the eventhandle is set
                     poller.RunAsync();
                 }
                 catch (Exception exception)

--- a/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
@@ -142,7 +142,7 @@ namespace heitech.zer0mqXt.core.patterns
             // create a new background thread with the response callback
             
             Exception faultingException = null;
-            Task.Run(() => 
+            _ = Task.Run(() => 
             {
                 try
                 {

--- a/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
@@ -142,7 +142,7 @@ namespace heitech.zer0mqXt.core.patterns
             // create a new background thread with the response callback
             
             Exception faultingException = null;
-            var task = Task.Run(() => 
+            Task.Run(() => 
             {
                 try
                 {

--- a/tests/zeromq.terminal/Program.cs
+++ b/tests/zeromq.terminal/Program.cs
@@ -33,7 +33,7 @@ namespace zeromq.terminal
 
         static async Task Main(string[] args)
         {
-            string key = "pubsub";//args.First();
+            string key = args.First();
             var actions = args.Where(x => _terminalActions.ContainsKey(x)).Select((x, index) => 
             {
                 var configuration = BuildConfig(args, index);

--- a/tests/zeromq.terminal/Program.cs
+++ b/tests/zeromq.terminal/Program.cs
@@ -33,7 +33,7 @@ namespace zeromq.terminal
 
         static async Task Main(string[] args)
         {
-            string key = "subcancel";//args.First();
+            string key = "pubsub";//args.First();
             var actions = args.Where(x => _terminalActions.ContainsKey(x)).Select((x, index) => 
             {
                 var configuration = BuildConfig(args, index);
@@ -75,29 +75,5 @@ namespace zeromq.terminal
             System.Console.WriteLine($"Running scenario [{key}] with config [{configuration.GetType().Name}] at address [{configuration.Address()}]");
             await _terminalActions[key](configuration);
         }
-
-        private static async Task RunPubSub(SocketConfiguration configuration)
-        {
-            // it works only for InProc right now
-            using var pubSub = new PubSub(configuration);
-            await Task.Run(() => 
-            {
-                System.Console.WriteLine("setting up the subscriber");
-                pubSub.SubscribeHandler<Message>((m) => System.Console.WriteLine("message came in: " + m.Text));
-            });
-            
-            System.Console.WriteLine("now publishes");
-            var input = "";
-            while (input != "quit")
-            {
-                System.Console.WriteLine("publish next one");
-                var xt = await pubSub.PublishAsync(new Message() {Text = "published!"});
-                System.Console.WriteLine(xt);
-
-                input = Console.ReadLine();
-            }
-        }
-
-        private class Message { public string Text { get; set; } }
     }
 }

--- a/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
+++ b/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
@@ -41,14 +41,13 @@ namespace zeromq.terminal.PubSubTests
             using var cts = new CancellationTokenSource();
             var token = cts.Token;
             socket.RegisterSubscriber<PubSubMessage>(msg => System.Console.WriteLine("msg received: " + msg.Message), token);
-            // cts.Cancel();
+            cts.Cancel();
             System.Console.WriteLine("try multiple Publishes");
             foreach (var item in Enumerable.Range(0, 3))
             {
-                //todo Does not yet work without the console readline. A Poller is probably in order with receive ready function notifying of new Published messages
                 await socket.PublishAsync(new PubSubMessage { Message = "Published with cancellation"});
-                Console.ReadLine();
             }
+            System.Console.WriteLine("press any key to exit");
             Console.ReadLine();
             socket.Dispose();
         }

--- a/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
+++ b/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using heitech.zer0mqXt.core;
+using heitech.zer0mqXt.core.infrastructure;
+using heitech.zer0mqXt.core.Main;
+
+namespace zeromq.terminal.PubSubTests
+{
+    public class PubSubScenarios
+    {
+        // socket came late, for now no refactoring of all tests desired
+        private static ISocket ToSocket(SocketConfiguration configuration)
+        {
+            if (configuration is SocketConfiguration.Tcp tcp)
+            {
+                string port = tcp.Address().Split(":").Last();
+                return Zer0Mq.Go().BuildWithTcp("localhost", port);
+            }
+            else
+            {
+                return Zer0Mq.Go().BuildWithInProc(configuration.Address().Split("//").Last());
+            }
+        }
+
+        internal static async Task SimplePubSub(SocketConfiguration configuration)
+        {
+            ISocket socket = ToSocket(configuration);
+            socket.RegisterSubscriber<PubSubMessage>(msg => System.Console.WriteLine("msg received: " + msg.Message));
+            await socket.PublishAsync(new PubSubMessage { Message = "Published simply"});
+
+            Console.ReadLine();
+
+            socket.Dispose();
+        }
+
+        internal static async Task PubSubWithCancellation(SocketConfiguration configuration)
+        {
+            ISocket socket = ToSocket(configuration);
+            using var cts = new CancellationTokenSource();
+            var token = cts.Token;
+            socket.RegisterSubscriber<PubSubMessage>(msg => System.Console.WriteLine("msg received: " + msg.Message), token);
+            // cts.Cancel();
+            System.Console.WriteLine("try multiple Publishes");
+            foreach (var item in Enumerable.Range(0, 3))
+            {
+                //todo Does not yet work without the console readline. A Poller is probably in order with receive ready function notifying of new Published messages
+                await socket.PublishAsync(new PubSubMessage { Message = "Published with cancellation"});
+                Console.ReadLine();
+            }
+            Console.ReadLine();
+            socket.Dispose();
+        }
+
+        public class PubSubMessage
+        {
+            public string Message { get; set; }
+        }
+    }
+}

--- a/unit-tests/heitech.zer0mqXt.core.tests/PubSubTests.cs
+++ b/unit-tests/heitech.zer0mqXt.core.tests/PubSubTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using heitech.zer0mqXt.core.infrastructure;
+using heitech.zer0mqXt.core.Main;
 using heitech.zer0mqXt.core.patterns;
 using Xunit;
 
@@ -15,22 +17,21 @@ namespace heitech.zer0mqXt.core.tests
         {
             // Arrange
             Message incoming = null;
-            bool unsubscirbeNow = false;
             var message = new Message { ThisIsAPublishedMessageText = "published a message", Array = new [] { 1, 2, 3, 4}};
 
             SocketConfiguration config = new ConfigurationTestData().GetSocketConfigInProc;
             config.Logger.SetSilent();
             var sut = new PubSub(config);
 
-            sut.SubscribeHandler<Message>(callback: m => incoming = m, unsubscribeWhen: () => unsubscirbeNow);
+            var xtResult = sut.SubscribeHandler<Message>(callback: m => incoming = m, CancellationToken.None);
 
             // Act
             await sut.PublishAsync<Message>(message);
 
             // Assert
-            await Task.Delay(250);
-            unsubscirbeNow = true;
+            await Task.Delay(500);
             Assert.NotNull(incoming);
+            Assert.True(xtResult.IsSuccess);
             Assert.Equal(message.Array, incoming.Array);
             Assert.Equal(message.ThisIsAPublishedMessageText, incoming.ThisIsAPublishedMessageText);
             sut.Dispose();
@@ -39,15 +40,44 @@ namespace heitech.zer0mqXt.core.tests
         [Fact]
         public async Task Publish_without_server_throws()
         {
-            SocketConfiguration config = new ConfigurationTestData().GetSocketConfigInProc;
+            var config = new ConfigurationTestData().GetSocketConfigInProc;
             var sut = new PubSub(config);
 
             // Act
-            Func<Task> pub = async () =>  await sut.PublishAsync<Message>(new Message());
+            Func<Task> pub = async () => await sut.PublishAsync<Message>(new Message());
 
             // Assert
-            await Assert.ThrowsAsync<NetMQ.EndpointNotFoundException>(pub);
+            bool noException = false;
+            try
+            {
+                await pub();
+                noException = true;
+            }
+            catch (System.Exception)
+            {
+                noException = false;
+            }
             sut.Dispose();
+            Assert.True(noException);
+        }
+
+        [Fact]
+        public async Task Subscriber_Cancellation_works()
+        {
+            // Arrange
+            var socket = Zer0Mq.Go().BuildWithInProc(Guid.NewGuid().ToString() + "-Subscriber-cancellation");
+            bool wasReceived = false;
+            var tokenSource = new CancellationTokenSource();
+            var token = tokenSource.Token;
+            tokenSource.Cancel();
+            socket.RegisterSubscriber<Message>(msg => wasReceived = true, token);
+            
+            // Act
+            await socket.PublishAsync<Message>(new Message());
+            
+            // Assert
+            Assert.False(wasReceived);
+            
         }
 
         [Fact]

--- a/unit-tests/heitech.zer0mqXt.core.tests/PubSubTests.cs
+++ b/unit-tests/heitech.zer0mqXt.core.tests/PubSubTests.cs
@@ -23,13 +23,15 @@ namespace heitech.zer0mqXt.core.tests
             config.Logger.SetSilent();
             var sut = new PubSub(config);
 
-            var xtResult = sut.SubscribeHandler<Message>(callback: m => incoming = m, CancellationToken.None);
+            var waitHandle = new ManualResetEvent(false);
+
+            var xtResult = sut.SubscribeHandler<Message>(callback: m => { incoming = m; waitHandle.Set(); } , CancellationToken.None);
 
             // Act
             await sut.PublishAsync<Message>(message);
 
             // Assert
-            await Task.Delay(500);
+            waitHandle.WaitOne();
             Assert.NotNull(incoming);
             Assert.True(xtResult.IsSuccess);
             Assert.Equal(message.Array, incoming.Array);

--- a/unit-tests/heitech.zer0mqXt.core.tests/PubSubTests.cs
+++ b/unit-tests/heitech.zer0mqXt.core.tests/PubSubTests.cs
@@ -47,18 +47,9 @@ namespace heitech.zer0mqXt.core.tests
             Func<Task> pub = async () => await sut.PublishAsync<Message>(new Message());
 
             // Assert
-            bool noException = false;
-            try
-            {
-                await pub();
-                noException = true;
-            }
-            catch (System.Exception)
-            {
-                noException = false;
-            }
+            await pub();
             sut.Dispose();
-            Assert.True(noException);
+            // no assert as no exception is expected otherwiese the test would fail at the call to the function pub()
         }
 
         [Fact]


### PR DESCRIPTION
- Added manual integration tests from the shell (PubSubScenarios - simple and subscribercancel)
- Added Unit Tests for subscriber cancel
-

- Refactored the PubSub Patterns class to use similar concepts as the RqRep Server part.
- namely: internal handler class, NetMQ.Poller for several messages simultaneously and correct handling of Dispose for the poller and sockets)