### PR TITLE
Added .ConfigureAwait(false) to every await call

### DIFF
--- a/src/heitech.zer0mqXt.core/Main/Socket.cs
+++ b/src/heitech.zer0mqXt.core/Main/Socket.cs
@@ -32,7 +32,7 @@ namespace heitech.zer0mqXt.core.Main
         public async Task PublishAsync<TMessage>(TMessage message) 
             where TMessage : class, new()
         {
-            var xtResult = await _pubSub.PublishAsync(message);
+            var xtResult = await _pubSub.PublishAsync(message).ConfigureAwait(false);
 
             ThrowOnNonSuccess(xtResult);
         }
@@ -55,7 +55,7 @@ namespace heitech.zer0mqXt.core.Main
             where TRequest : class, new()
             where TResult : class, new()
         {
-            var xtResult = await _rqRep.RequestAsync<TRequest, TResult>(request);
+            var xtResult = await _rqRep.RequestAsync<TRequest, TResult>(request).ConfigureAwait(false);
             ThrowOnNonSuccess(xtResult);
 
             return xtResult.GetResult();
@@ -80,7 +80,7 @@ namespace heitech.zer0mqXt.core.Main
         public async Task SendAsync<TMessage>(TMessage message) 
             where TMessage : class, new()
         {
-            var xtResult = await _sendReceive.SendAsync(message);
+            var xtResult = await _sendReceive.SendAsync(message).ConfigureAwait(false);
 
             ThrowOnNonSuccess(xtResult);
         }
@@ -111,12 +111,12 @@ namespace heitech.zer0mqXt.core.Main
             where TRequest : class, new()
             where TResult : class, new()
         {
-            var xtResult = await _rqRep.RequestAsync<TRequest, TResult>(request);
+            var xtResult = await _rqRep.RequestAsync<TRequest, TResult>(request).ConfigureAwait(false);
 
             if (xtResult.IsSuccess)
-                await successCallback(xtResult.GetResult());
+                await successCallback(xtResult.GetResult()).ConfigureAwait(false);
             else
-                await failureCallback();
+                await failureCallback().ConfigureAwait(false);
             
             return xtResult.IsSuccess;
         }
@@ -143,7 +143,7 @@ namespace heitech.zer0mqXt.core.Main
         public async Task<bool> TrySendAsync<TMessage>(TMessage message) 
             where TMessage : class, new()
         {
-            var xtResult = await _sendReceive.SendAsync(message);
+            var xtResult = await _sendReceive.SendAsync(message).ConfigureAwait(false);
             return xtResult.IsSuccess;
         }
 
@@ -162,7 +162,7 @@ namespace heitech.zer0mqXt.core.Main
         public async Task<bool> TryPublishAsync<TMessage>(TMessage message) 
             where TMessage : class, new()
         {
-            var result = await _pubSub.PublishAsync<TMessage>(message);
+            var result = await _pubSub.PublishAsync<TMessage>(message).ConfigureAwait(false);
             return result.IsSuccess;
         }
     }

--- a/src/heitech.zer0mqXt.core/Patterns/PubSub.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/PubSub.cs
@@ -42,7 +42,7 @@ namespace heitech.zer0mqXt.core.patterns
                     }
 
                     return XtResult<TMessage>.Success(message, "publish");
-                });
+                }).ConfigureAwait(false);
                 
             }
             catch (System.Exception ex)
@@ -149,7 +149,7 @@ namespace heitech.zer0mqXt.core.patterns
                 Exception exception = null;
                 try
                 {
-                    _socketDelegate = async (s, arg) => await HandleAsync();
+                    _socketDelegate = async (s, arg) => await HandleAsync().ConfigureAwait(false);
                     _socket.ReceiveReady += _socketDelegate;
                     
                     // todo use actual topics instead of catchall
@@ -189,7 +189,7 @@ namespace heitech.zer0mqXt.core.patterns
                     if (this._asyncCallback is null)
                         _syncCallback(msg);
                     else
-                        await _asyncCallback(msg);
+                        await _asyncCallback(msg).ConfigureAwait(false);
                 }
                 catch (NetMQ.TerminatingException trmnt)
                 {

--- a/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/RqRep.cs
@@ -24,15 +24,15 @@ namespace heitech.zer0mqXt.core.patterns
         {
             try
             {
-                return await DoRequestAsync<T, TResult>(request);
+                return await DoRequestAsync<T, TResult>(request).ConfigureAwait(false);
             }
             catch (NetMQ.EndpointNotFoundException ntfnd)
             {
                 _configuration.Logger.Log(new ErrorLogMsg($"NetMQ.Endpoint could not be found at {_configuration.Address()}: " + ntfnd.Message));
-                await Task.Delay((int)_configuration.TimeOut.TotalMilliseconds);
+                await Task.Delay((int)_configuration.TimeOut.TotalMilliseconds).ConfigureAwait(false);
                 try
                 {
-                    return await DoRequestAsync<T, TResult>(request);
+                    return await DoRequestAsync<T, TResult>(request).ConfigureAwait(false);
                 }
                 catch (System.Exception inner)
                 {
@@ -81,7 +81,7 @@ namespace heitech.zer0mqXt.core.patterns
                 return xtResult.IsSuccess
                         ? XtResult<TResult>.Success(xtResult.GetResult(), operation)
                         : XtResult<TResult>.Failed(xtResult.Exception, operation);
-            });
+            }).ConfigureAwait(false);
         }
         #endregion
 
@@ -150,7 +150,7 @@ namespace heitech.zer0mqXt.core.patterns
 
                     // add to poller and register handler
                     poller.Add(responseSocket);
-                    receiveHandler = async (s, e) => await ResponseHandlerCallback(responseSocket, handler, token);
+                    receiveHandler = async (s, e) => await ResponseHandlerCallback(responseSocket, handler, token).ConfigureAwait(false);
                     responseSocket.ReceiveReady += receiveHandler;
 
                     poller.RunAsync();
@@ -203,7 +203,7 @@ namespace heitech.zer0mqXt.core.patterns
                 if (asyncCallback is null)
                     return syncCallback(request);
                 else
-                    return await asyncCallback(request);
+                    return await asyncCallback(request).ConfigureAwait(false);
             }
         }
 
@@ -231,7 +231,7 @@ namespace heitech.zer0mqXt.core.patterns
                     _configuration.Logger.Log(new DebugLogMsg($"handling response for [Request:{typeof(T)}] and [Response:{typeof(TResult)}]"));
 
                     var actualRequestResult = incomingRequest.ParseRqRepMessage<T>(_configuration);
-                    TResult result = await handler.HandleAsync(actualRequestResult);
+                    TResult result = await handler.HandleAsync(actualRequestResult).ConfigureAwait(false);
 
                     response = new RequestReplyMessage<TResult>(_configuration, result, actualRequestResult.IsSuccess);
                     _configuration.Logger.Log(new DebugLogMsg($"sending response for [Request:{typeof(T)}] and [Response:{typeof(TResult)}]"));

--- a/src/heitech.zer0mqXt.core/Patterns/SendReceive.cs
+++ b/src/heitech.zer0mqXt.core/Patterns/SendReceive.cs
@@ -20,7 +20,7 @@ namespace heitech.zer0mqXt.core.patterns
         public async Task<XtResult> SendAsync<TMessage>(TMessage message)
             where TMessage : class, new()
         {
-            var xtResult = await _rqRs.RequestAsync<TMessage, EmptyResponse>(message);
+            var xtResult = await _rqRs.RequestAsync<TMessage, EmptyResponse>(message).ConfigureAwait(false);
             return xtResult.IsSuccess
                    ? XtResult.Success("send")
                    : XtResult.Failed(xtResult.Exception, "send");
@@ -38,7 +38,7 @@ namespace heitech.zer0mqXt.core.patterns
         public XtResult SetupReceiverAsync<TMessage>(Func<TMessage, Task> asyncCallback, CancellationToken token = default)
             where TMessage : class, new()
         {
-            var setupResult = _rqRs.RespondAsync<TMessage, EmptyResponse>(async (msg) => { await asyncCallback(msg); return new EmptyResponse(); }, token);
+            var setupResult = _rqRs.RespondAsync<TMessage, EmptyResponse>(async (msg) => { await asyncCallback(msg).ConfigureAwait(false); return new EmptyResponse(); }, token);
 
             return setupResult.IsSuccess
                    ? XtResult.Success("receiveAsync")


### PR DESCRIPTION
Just started playing with Roslyn, made a rewriter that adds `.ConfigureAwait(false)` (or changes it into true in some classes/methods, if you ask nicely) to every await expression without one and found your issue https://github.com/TimoHeiten/zer0mqXt/issues/30 that asks exactly for that, so I ran it on your core project and commited the results. Hope it didnt miss anything.