### PR TITLE
Pub sub with multiple subscribers is now available.

### DIFF
--- a/src/heitech.zer0mqXt.core/IZer0MqBuilder.cs
+++ b/src/heitech.zer0mqXt.core/IZer0MqBuilder.cs
@@ -14,6 +14,11 @@ namespace heitech.zer0mqXt.core
         IZer0MqBuilder SilenceLogger();
         IZer0MqBuilder SetSerializer(ISerializerAdapter adapter);
 
+        ///<summary>
+        /// Important to prime a socket as a publishing one. Can only be used for one Publisher at a time
+        ///</summary>
+        IZer0MqBuilder UsePublisher();
+
         ISocket BuildWithTcp(string host, string port);
         ISocket BuildWithInProc(string pipeName);
     }

--- a/src/heitech.zer0mqXt.core/Main/Socket.cs
+++ b/src/heitech.zer0mqXt.core/Main/Socket.cs
@@ -29,6 +29,13 @@ namespace heitech.zer0mqXt.core.Main
             _sendReceive.Dispose();
         }
 
+        // we need to use Bind for a publisher so Subscribers can connect to it.
+        // this is due to the mechanisms integral to Zer0MqItself
+        internal void PrimePublisher()
+        {
+            _pubSub.PrimePublisher();
+        }
+
         public async Task PublishAsync<TMessage>(TMessage message) 
             where TMessage : class, new()
         {

--- a/src/heitech.zer0mqXt.core/Main/Socket.cs
+++ b/src/heitech.zer0mqXt.core/Main/Socket.cs
@@ -29,8 +29,8 @@ namespace heitech.zer0mqXt.core.Main
             _sendReceive.Dispose();
         }
 
-        // we need to use Bind for a publisher so Subscribers can connect to it.
-        // this is due to the mechanisms integral to Zer0MqItself
+        // we need to use Bind for a publisher so Subscribers can connect to it
+        // this is due to the mechanisms integral to Zer0Mq itself
         internal void PrimePublisher()
         {
             _pubSub.PrimePublisher();

--- a/src/heitech.zer0mqXt.core/Main/Zer0Mq.cs
+++ b/src/heitech.zer0mqXt.core/Main/Zer0Mq.cs
@@ -9,6 +9,7 @@ namespace heitech.zer0mqXt.core.Main
         private bool _isSilent;
         private ILogger _logger;
         private ISerializerAdapter _serializer;
+        private bool _usePublisher;
 
         private Zer0Mq()
         {
@@ -46,7 +47,18 @@ namespace heitech.zer0mqXt.core.Main
             if (_isSilent)
                 _logger.SetSilent();
 
-            return new Socket(configuration);
+            var socket = new Socket(configuration);
+
+            if (_usePublisher)
+                socket.PrimePublisher();
+
+            return socket;
+        }
+
+        public IZer0MqBuilder UsePublisher()
+        {
+            _usePublisher = true;
+            return this;
         }
 
         public IZer0MqBuilder SilenceLogger()

--- a/src/heitech.zer0mqXt.core/Transport/Message.cs
+++ b/src/heitech.zer0mqXt.core/Transport/Message.cs
@@ -44,9 +44,9 @@ namespace heitech.zer0mqXt.core.transport
             const string operation = "parse-pub-sub-msg";
             if (msg.FrameCount != 2)
             {
-                var exc = ZeroMqXtSocketException.MissedExpectedFrameCount(msg.FrameCount);
+                var exc = ZeroMqXtSocketException.MissedExpectedFrameCount(msg.FrameCount, expectedCount: 2);
                 configuration.Logger.Log(new DebugLogMsg(exc.Message));
-                return XtResult<TMessage>.Failed(ZeroMqXtSocketException.MissedExpectedFrameCount(msg.FrameCount, 2));
+                return XtResult<TMessage>.Failed(ZeroMqXtSocketException.MissedExpectedFrameCount(msg.FrameCount, expectedCount: 2));
             }
             
             var receivedType = configuration.Serializer.Deserialize<string>(msg.First.ToByteArray());

--- a/tests/zeromq.terminal/Program.cs
+++ b/tests/zeromq.terminal/Program.cs
@@ -28,15 +28,15 @@ namespace zeromq.terminal
                 ["pubsub"] = PubSubScenarios.SimplePubSub,
                 ["subcancel"] = PubSubScenarios.PubSubWithCancellation,
 
-                [DESCRIBE] = Describe
+                [HELP] = ShowHelp
             };
         }
 
-        const string DESCRIBE = "describe";
-        static Task Describe(SocketConfiguration _)
+        const string HELP = "help";
+        static Task ShowHelp(SocketConfiguration _)
         {
             System.Console.WriteLine("Use one of the following keys as cmd param to test different scenarios:");
-            string keys = string.Join(Environment.NewLine, _terminalActions.Keys.Where(x => x != DESCRIBE).Select((name, index) => $"{++index}\t{name}"));
+            string keys = string.Join(Environment.NewLine, _terminalActions.Keys.Where(x => x != HELP).Select((name, index) => $"{++index}\t{name}"));
             System.Console.WriteLine(keys);
 
             return Task.CompletedTask;
@@ -44,7 +44,7 @@ namespace zeromq.terminal
 
         static async Task Main(string[] args)
         {
-            string key = args.FirstOrDefault() ?? DESCRIBE;
+            string key = args.FirstOrDefault() ?? HELP;
             var actions = args.Where(x => _terminalActions.ContainsKey(x)).Select((x, index) => 
             {
                 var configuration = BuildConfig(args, index);

--- a/tests/zeromq.terminal/Program.cs
+++ b/tests/zeromq.terminal/Program.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System;
 using heitech.zer0mqXt.core.infrastructure;
-using heitech.zer0mqXt.core.patterns;
 using zeromq.terminal.RqRepTests;
 using zeromq.terminal.PubSubTests;
 
@@ -28,12 +27,24 @@ namespace zeromq.terminal
 
                 ["pubsub"] = PubSubScenarios.SimplePubSub,
                 ["subcancel"] = PubSubScenarios.PubSubWithCancellation,
+
+                [DESCRIBE] = Describe
             };
+        }
+
+        const string DESCRIBE = "describe";
+        static Task Describe(SocketConfiguration _)
+        {
+            System.Console.WriteLine("Use one of the following keys as cmd param to test different scenarios:");
+            string keys = string.Join(Environment.NewLine, _terminalActions.Keys.Where(x => x != DESCRIBE).Select((name, index) => $"{++index}\t{name}"));
+            System.Console.WriteLine(keys);
+
+            return Task.CompletedTask;
         }
 
         static async Task Main(string[] args)
         {
-            string key = args.First();
+            string key = args.FirstOrDefault() ?? DESCRIBE;
             var actions = args.Where(x => _terminalActions.ContainsKey(x)).Select((x, index) => 
             {
                 var configuration = BuildConfig(args, index);

--- a/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
+++ b/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
@@ -16,11 +16,11 @@ namespace zeromq.terminal.PubSubTests
             if (configuration is SocketConfiguration.Tcp tcp)
             {
                 string port = tcp.Address().Split(":").Last();
-                return Zer0Mq.Go().BuildWithTcp("localhost", port);
+                return Zer0Mq.Go().UsePublisher().BuildWithTcp("localhost", port);
             }
             else
             {
-                return Zer0Mq.Go().BuildWithInProc(configuration.Address().Split("//").Last());
+                return Zer0Mq.Go().UsePublisher().BuildWithInProc(configuration.Address().Split("//").Last());
             }
         }
 
@@ -30,6 +30,7 @@ namespace zeromq.terminal.PubSubTests
             socket.RegisterSubscriber<PubSubMessage>(msg => System.Console.WriteLine("msg received: " + msg.Message));
             await socket.PublishAsync(new PubSubMessage { Message = "Published simply"});
 
+            System.Console.WriteLine("press any enter to exit");
             Console.ReadLine();
 
             socket.Dispose();
@@ -47,7 +48,7 @@ namespace zeromq.terminal.PubSubTests
             {
                 await socket.PublishAsync(new PubSubMessage { Message = "Published with cancellation"});
             }
-            System.Console.WriteLine("press any key to exit");
+            System.Console.WriteLine("press enter to exit");
             Console.ReadLine();
             socket.Dispose();
         }

--- a/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
+++ b/tests/zeromq.terminal/PubSubTests/PubSubScenarios.cs
@@ -30,7 +30,7 @@ namespace zeromq.terminal.PubSubTests
             socket.RegisterSubscriber<PubSubMessage>(msg => System.Console.WriteLine("msg received: " + msg.Message));
             await socket.PublishAsync(new PubSubMessage { Message = "Published simply"});
 
-            System.Console.WriteLine("press any enter to exit");
+            System.Console.WriteLine("press enter to exit");
             Console.ReadLine();
 
             socket.Dispose();

--- a/tests/zeromq.terminal/RqRepTests/RqRepScenarios.cs
+++ b/tests/zeromq.terminal/RqRepTests/RqRepScenarios.cs
@@ -83,7 +83,7 @@ namespace zeromq.terminal.RqRepTests
             socket.Respond<Request, Response>((r) => new Response());
 
             var response = await socket.RequestAsync<Request, Response>(new Request());
-            System.Console.WriteLine(response.InsideResponse);
+            System.Console.WriteLine(response.InsideResponse + " works");
         }
 
         internal static Task Contest(SocketConfiguration _)


### PR DESCRIPTION
The Publisher needs to use the NetMQ.Bind instead of the subscribers.

NetMQ has Bind and Connect:
- Bind is used to setup a queue where others can later join to
- Connect establishes a connection to an existing queue

When Bind was used on a subscriber, it owns the queue and with a publisher/other subscribers connecting to this queue via Connect(), creates weird an unexpected behavior.

Solution:
Use a Primer function on creating the Socket itself. --> UsePublisher in our case. It should not be implicit, because we do not want to have the port blocked autotmatically, just because we create an instance of the socket. So control is needed with this primer function.